### PR TITLE
1.1.0-SNAPSHOT: Charsets and workflows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Maven build and test
 
 on:
   push:
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.11
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 21
 
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,6 @@ In particular, the *dataset* package and its sub-packages provide a simple abstr
 
 ## Status
 
-![Java CI with Maven](https://github.com/stacs-srg/ciesvium/workflows/Java%20CI%20with%20Maven/badge.svg) 
+* ![Java CI with Maven](https://github.com/stacs-srg/ciesvium/workflows/Java%20CI%20with%20Maven/badge.svg) 
 
 {% include navigation.html %}

--- a/docs/usage/data-sets/index.md
+++ b/docs/usage/data-sets/index.md
@@ -1,8 +1,5 @@
 ## Usage: Data Sets
 
-The <a href="https://quicksilver.host.cs.st-andrews.ac.uk/apidocs/ciesvium/?uk/ac/standrews/cs/utilities/dataset/DataSet.html">DataSet</a>
-provides a simple abstraction over a plain-text row-column-structured data set. Data is represented as a list of rows, each of which is a
-list of strings, plus a list of string column labels. Data can be read from and written to CSV files, and filtered with relational-style
-selection and projection operations.
+The **`DataSet`** provides a simple abstraction over a plain-text row-column-structured data set. Data is represented as a list of rows, each of which is a list of strings, plus a list of string column labels. Data can be read from and written to CSV files, and filtered with relational-style selection and projection operations.
 
 {% include navigation.html %}

--- a/docs/usage/derived-data-sets/index.md
+++ b/docs/usage/derived-data-sets/index.md
@@ -1,166 +1,190 @@
 ## Usage: Derived Data Sets
 
-A derived data set allows a new data set to be defined in terms of various transformations applied to an existing data
-set, by extending class <a href="https://quicksilver.host.cs.st-andrews.ac.uk/apidocs/ciesvium/?uk/ac/standrews/cs/utilities/dataset/derived/DerivedDataSet.html">DerivedDataSet</a>.
+A derived data set allows a new data set to be defined in terms of various transformations applied to an existing data set, by extending class **DerivedDataSet**.
+
 The following methods need to be defined:
 
-    public DataSet getSourceDataSet() throws IOException;
-    public abstract DataSet getDerivedDataSet(DataSet source_data_set) throws IOException;
+```java
+public DataSet getSourceDataSet() throws IOException;
+public abstract DataSet getDerivedDataSet(DataSet source_data_set) throws IOException;
+```
 
 For example, to add a new auto-incremented ID column to a data set:
 
-    public class DerivedDataWithIDColumn extends DerivedDataSet {
+```java
+public class DerivedDataWithIDColumn extends DerivedDataSet {
 
-        protected DerivedDataWithIDColumn() throws IOException {}
+    protected DerivedDataWithIDColumn() throws IOException {}
 
-        public DataSet getSourceDataSet() {
+    public DataSet getSourceDataSet() {
 
-            final DataSet data = new DataSet(Arrays.asList("col1", "col2", "col3"));
+        final DataSet data = new DataSet(Arrays.asList("col1", "col2", "col3"));
 
-            data.addRow(Arrays.asList("a", "b", "c"));
-            data.addRow(Arrays.asList("d", "e", "f"));
+        data.addRow(Arrays.asList("a", "b", "c"));
+        data.addRow(Arrays.asList("d", "e", "f"));
 
-            return data;
-        }
-
-        public DataSet getDerivedDataSet(final DataSet source_data_set) {
-
-            return source_data_set.extend(addIdColumn());
-        }
+        return data;
     }
 
+    public DataSet getDerivedDataSet(final DataSet source_data_set) {
+
+        return source_data_set.extend(addIdColumn());
+    }
+}
+```
 If we print the source and derived data sets:
 
-    DerivedDataSet derived = new DerivedDataWithIDColumn();
-    derived.getSourceDataSet().print(System.out);
-    derived.print(System.out);
+```java
+DerivedDataSet derived = new DerivedDataWithIDColumn();
+derived.getSourceDataSet().print(System.out);
+derived.print(System.out);
+```
 
 We get:
 
-    col1,col2,col3
-    a,b,c
-    d,e,f
-    
-    col1,col2,col3,ID
-    a,b,c,1
-    d,e,f,2
+```txt
+col1,col2,col3
+a,b,c
+d,e,f
 
-In this example, the source data set is defined within the derived data set class, which perhaps isn't very useful.
-To pass it as a parameter we can define an anonymous derived class within a method:
+col1,col2,col3,ID
+a,b,c,1
+d,e,f,2
+```
 
-    public static DerivedDataSet makeDerivedDataSet(final DataSet original) throws IOException {
+In this example, the source data set is defined within the derived data set class, which perhaps isn't very useful. To pass it as a parameter we can define an anonymous derived class within a method:
 
-        return new DerivedDataSet() {
+```java
+public static DerivedDataSet makeDerivedDataSet(final DataSet original) throws IOException {
 
-            public DataSet getSourceDataSet() {
-                return original;
-            }
+    return new DerivedDataSet() {
 
-            public DataSet getDerivedDataSet(final DataSet source_data_set) {
-                return source_data_set.extend(addIdColumn());
-            }
-        };
-    }
+        public DataSet getSourceDataSet() {
+            return original;
+        }
+
+        public DataSet getDerivedDataSet(final DataSet source_data_set) {
+            return source_data_set.extend(addIdColumn());
+        }
+    };
+}
+```
     
 To move the ID column to the first position:
 
-    public static class DerivedDataWithIDColumnFirst extends DerivedDataSet {
+```java
+public static class DerivedDataWithIDColumnFirst extends DerivedDataSet {
 
-        protected DerivedDataWithIDColumnFirst() throws IOException {
-        }
-
-        public DataSet getSourceDataSet() throws IOException {
-            return new DerivedDataWithIDColumn();
-        }
-
-        public DataSet getDerivedDataSet(final DataSet source_data_set) {
-            return source_data_set.project(moveIdColumnToFirst(source_data_set.getColumnLabels()));
-        }
+    protected DerivedDataWithIDColumnFirst() throws IOException {
     }
-    
+
+    public DataSet getSourceDataSet() throws IOException {
+        return new DerivedDataWithIDColumn();
+    }
+
+    public DataSet getDerivedDataSet(final DataSet source_data_set) {
+        return source_data_set.project(moveIdColumnToFirst(source_data_set.getColumnLabels()));
+    }
+}
+```
+
 Which when instantiated and printed gives:
 
-    ID,col1,col2,col3
-    1,a,b,c
-    2,d,e,f
+```txt
+ID,col1,col2,col3
+1,a,b,c
+2,d,e,f
+```
     
 To filter rows, for example to omit any containing "b" in the third column:
 
-    public static class DerivedDataWithFilteredRows extends DerivedDataSet {
+```java
+public static class DerivedDataWithFilteredRows extends DerivedDataSet {
 
-        protected DerivedDataWithFilteredRows() throws IOException {
-        }
-
-        public DataSet getSourceDataSet() throws IOException {
-            return new DerivedDataWithIDColumnFirst();
-        }
-
-        public DataSet getDerivedDataSet(final DataSet source_data_set) {
-            return source_data_set.select((record, data_set) -> !record.get(2).equals("b"));
-        }
+    protected DerivedDataWithFilteredRows() throws IOException {
     }
+
+    public DataSet getSourceDataSet() throws IOException {
+        return new DerivedDataWithIDColumnFirst();
+    }
+
+    public DataSet getDerivedDataSet(final DataSet source_data_set) {
+        return source_data_set.select((record, data_set) -> !record.get(2).equals("b"));
+    }
+}
+```
 
 Which gives:
 
-    ID,col1,col2,col3
-    2,d,e,f
-    
+```txt
+ID,col1,col2,col3
+2,d,e,f
+```
+
 To renumber IDs:
 
-    public static class DerivedDataWithFilteredRowsAndRenumbered extends DerivedDataSet {
+```java
+public static class DerivedDataWithFilteredRowsAndRenumbered extends DerivedDataSet {
 
-        protected DerivedDataWithFilteredRowsAndRenumbered() throws IOException {
-        }
-
-        public DataSet getSourceDataSet() throws IOException {
-            return new DerivedDataWithFilteredRows();
-        }
-
-        public DataSet getDerivedDataSet(final DataSet source_data_set) {
-            return renumber(source_data_set);
-        }
+    protected DerivedDataWithFilteredRowsAndRenumbered() throws IOException {
     }
-    
+
+    public DataSet getSourceDataSet() throws IOException {
+        return new DerivedDataWithFilteredRows();
+    }
+
+    public DataSet getDerivedDataSet(final DataSet source_data_set) {
+        return renumber(source_data_set);
+    }
+}
+```
+
 Which gives:
 
-    ID,col1,col2,col3
-    1,d,e,f
+```txt
+ID,col1,col2,col3
+1,d,e,f
+```
 
 And finally, to transform individual data elements, in this case to make them all upper case:
 
-    public static class DerivedDataWithCapitalLetters extends DerivedDataSet {
+```java
+public static class DerivedDataWithCapitalLetters extends DerivedDataSet {
 
-        protected DerivedDataWithCapitalLetters() throws IOException {
-        }
-
-        public DataSet getSourceDataSet() throws IOException {
-            return new DerivedDataWithIDColumnFirst();
-        }
-
-        public DataSet getDerivedDataSet(final DataSet source_data_set) {
-
-            return source_data_set.map(new Mapper() {
-
-                public List<String> mapRecord(final List<String> record, final List<String> labels) {
-                    final List<String> new_row = new ArrayList<>();
-
-                    for (final String element : record) {
-                        new_row.add(element.toUpperCase());
-                    }
-                    return new_row;
-                }
-
-                public List<String> mapColumnLabels(final List<String> labels) {
-                    return labels;
-                }
-            });
-        }
+    protected DerivedDataWithCapitalLetters() throws IOException {
     }
+
+    public DataSet getSourceDataSet() throws IOException {
+        return new DerivedDataWithIDColumnFirst();
+    }
+
+    public DataSet getDerivedDataSet(final DataSet source_data_set) {
+
+        return source_data_set.map(new Mapper() {
+
+            public List<String> mapRecord(final List<String> record, final List<String> labels) {
+                final List<String> new_row = new ArrayList<>();
+
+                for (final String element : record) {
+                    new_row.add(element.toUpperCase());
+                }
+                return new_row;
+            }
+
+            public List<String> mapColumnLabels(final List<String> labels) {
+                return labels;
+            }
+        });
+    }
+}
+```
 
 Which gives:
 
-    ID,col1,col2,col3
-    1,A,B,C
-    2,D,E,F
+```txt
+ID,col1,col2,col3
+1,A,B,C
+2,D,E,F
+```
 
 {% include navigation.html %}

--- a/docs/usage/encrypted-data-sets/index.md
+++ b/docs/usage/encrypted-data-sets/index.md
@@ -1,9 +1,6 @@
 ## Usage: Encrypted Data Sets
 
-Encrypted data sets are based on <a href="https://quicksilver.host.cs.st-andrews.ac.uk/apidocs/ciesvium/?uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.html">EncryptedDataSet</a>,
-a subclass of <a href="https://quicksilver.host.cs.st-andrews.ac.uk/apidocs/ciesvium/?uk/ac/standrews/cs/utilities/dataset/DataSet.html">DataSet</a>.
-They allow the persistent data to be encrypted using either symmetric or public key encryption. The latter offers the
-convenience of avoiding explicit key management for authorized users.
+Encrypted data sets are based on **`EncryptedDataSet`**, a subclass of **`DataSet`**. They allow the persistent data to be encrypted using either symmetric or public key encryption. The latter offers the convenience of avoiding explicit key management for authorized users.
 
 ### Documentation
 

--- a/docs/usage/encrypted-data-sets/operations/decrypt-AES-key.md
+++ b/docs/usage/encrypted-data-sets/operations/decrypt-AES-key.md
@@ -1,17 +1,20 @@
 ## Operation: Decrypt AES Key
 
-This extracts a MIME-encoded AES key from a file containing the key
-encrypted with a number of authorized public keys. Each of the encrypted keys is decrypted in turn 
-with this user's private key, until a valid AES key is extracted, which is then printed.
+This extracts a MIME-encoded AES key from a file containing the key encrypted with a number of authorized public keys. Each of the encrypted keys is decrypted in turn with this user's private key, until a valid AES key is extracted, which is then printed.
 
 **Java class**:
- 
-    uk.ac.standrews.cs.util.dataset.encrypted.util.DecryptAESKey
- 
-**Bash script**:
- 
-    src/main/scripts/decrypt-aes-key.sh <path of AES key encrypted for authorized users>
 
-**Result**: extracted key is printed to standard out
+```java
+uk.ac.standrews.cs.util.dataset.encrypted.util.DecryptAESKey
+```
+
+**Bash script**:
+```sh
+src/main/scripts/decrypt-aes-key.sh <path of AES key encrypted for authorized users>
+```
+
+**Result**:
+
+Extracted key is printed to standard out
 
 {% include navigation.html %}

--- a/docs/usage/encrypted-data-sets/operations/decrypt-file-with-AES-key.md
+++ b/docs/usage/encrypted-data-sets/operations/decrypt-file-with-AES-key.md
@@ -3,13 +3,19 @@
 This decrypts an encrypted file using a given MIME-encoded AES key.
 
 **Java class**:
- 
-    uk.ac.standrews.cs.util.dataset.encrypted.util.DecryptFileWithAESKey
+
+```java
+uk.ac.standrews.cs.util.dataset.encrypted.util.DecryptFileWithAESKey
+```
  
 **Bash script**:
- 
-    src/main/scripts/decrypt-file-with-aes-key.sh <path of AES key encrypted for authorized users> <path of encrypted file> <path of new plain-text file>
 
-**Result**: decrypted file is written to specified path
+```sh
+src/main/scripts/decrypt-file-with-aes-key.sh <path of AES key encrypted for authorized users> <path of encrypted file> <path of new plain-text file>
+```
+
+**Result**:
+
+Decrypted file is written to specified path
 
 {% include navigation.html %}

--- a/docs/usage/encrypted-data-sets/operations/decrypt-file-with-encrypted-AES-key.md
+++ b/docs/usage/encrypted-data-sets/operations/decrypt-file-with-encrypted-AES-key.md
@@ -1,18 +1,20 @@
 ## Operation: Decrypt File With Encrypted AES Key
 
-This decrypts an encrypted file using an AES key which is extracted from a file containing the key
-encrypted with a number of authorized public keys. Each of the encrypted keys is decrypted in turn 
-with this user's private key, until a valid AES key is extracted, which is then used to decrypt the 
-file.
+This decrypts an encrypted file using an AES key which is extracted from a file containing the key encrypted with a number of authorized public keys. Each of the encrypted keys is decrypted in turn with this user's private key, until a valid AES key is extracted, which is then used to decrypt the file.
 
 **Java class**:
- 
-    uk.ac.standrews.cs.util.dataset.encrypted.util.DecryptFileWithEncryptedAESKey
- 
-**Bash script**:
- 
-    src/main/scripts/decrypt-file-with-encrypted-aes-key.sh <path of AES key encrypted for authorized users> <path of encrypted file> <path of new plain-text file>
 
-**Result**: decrypted file is written to specified path
+```java
+uk.ac.standrews.cs.util.dataset.encrypted.util.DecryptFileWithEncryptedAESKey
+```
+
+**Bash script**:
+```sh
+src/main/scripts/decrypt-file-with-encrypted-aes-key.sh <path of AES key encrypted for authorized users> <path of encrypted file> <path of new plain-text file>
+```
+
+**Result**:
+
+Decrypted file is written to specified path
 
 {% include navigation.html %}

--- a/docs/usage/encrypted-data-sets/operations/encrypt-AES-key.md
+++ b/docs/usage/encrypted-data-sets/operations/encrypt-AES-key.md
@@ -1,31 +1,35 @@
 ## Operation: Encrypt AES Key
 
-This encrypts a MIME-encoded AES key using public-key encryption. The AES key is encrypted separately with each of a
-number of authorized public keys read from a specified file. The resulting encrypted versions of the AES key are written
-to a given file.
+This encrypts a MIME-encoded AES key using public-key encryption. The AES key is encrypted separately with each of a number of authorized public keys read from a specified file. The resulting encrypted versions of the AES key are written to a given file.
 
-Each public key is assumed to be in [PEM format](http://serverfault.com/questions/9708/what-is-a-pem-file-and-how-does-it-differ-from-other-openssl-generated-key-file),
-and delimited by *begin* and *end* comments as illustrated in the example
-below. The email address shown preceding each key is for reference only, and is ignored by this method. See later on
-this page for an example of how to generate a PEM key pair.
+Each public key is assumed to be in [PEM format](http://serverfault.com/questions/9708/what-is-a-pem-file-and-how-does-it-differ-from-other-openssl-generated-key-file), and delimited by *begin* and *end* comments as illustrated in the example below. The email address shown preceding each key is for reference only, and is ignored by this method. See later on this page for an example of how to generate a PEM key pair.
 
 **Java class**:
- 
-    uk.ac.standrews.cs.util.dataset.encrypted.util.EncryptAESKey
- 
-**Bash script**:
- 
-    src/main/scripts/encrypt-aes-key.sh <mime-encoded AES key> <path of authorized public keys file> <path of AES key encrypted for authorized users>
 
-**Result**: file containing encrypted versions of the key is written to specified path
+```java
+uk.ac.standrews.cs.util.dataset.encrypted.util.EncryptAESKey
+```
+
+**Bash script**:
+
+```sh
+src/main/scripts/encrypt-aes-key.sh <mime-encoded AES key> <path of authorized public keys file> <path of AES key encrypted for authorized users>
+```
+
+**Result**:
+
+File containing encrypted versions of the key is written to specified path
 
 **Example input key**:
 
-<pre>lr8Rnrakxi1+SYbX+Xnieg==</pre>
+```txt
+lr8Rnrakxi1+SYbX+Xnieg==
+```
 
 **Example input file**:
 
-<pre>graham.kirby@st-andrews.ac.uk
+```txt
+graham.kirby@st-andrews.ac.uk
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzTDV8GGUcZByuw2zRu8+
 SEbJTg+lT9Vx8H+5N/BNUViHVZb+zToQdzwnRE2vqQAdRfLwoNBHoiD+buUivy+l
@@ -54,11 +58,12 @@ wa/kd3P3UxKbT254QUUGa5fHlY8t30N84BGdE/3yI4Hi1kwdJjRStXUjY6qcjWC0
 U0CNTNEPxzvuSntWkezz8vI5SI9CqWP2UkTUUOcXuVMPiNFdyGnjH71ssgQh/14p
 AYGxSMMYJyAPfDCAgaYGpIt4DrthONHrhWltpC0cAk3Xsqa2au61IMJYcyDfvn6u
 tQIDAQAB
------END PUBLIC KEY-----</pre>
+-----END PUBLIC KEY-----
+```
 
 **Example output file**:
-
-<pre>YAgStYOQwmEMYyiRafzyuy+ixlLRzOwd2kXiWiV00758TtUoZDH4BvJOtcVt5ydxDLN6QxA0KKOt
+```txt
+YAgStYOQwmEMYyiRafzyuy+ixlLRzOwd2kXiWiV00758TtUoZDH4BvJOtcVt5ydxDLN6QxA0KKOt
 h7nbIuFjI76sOGZ+jmxa4gjpbSxJJpfa3LI7/9ygt5oLQyHxbsfCMF+xR/Czz4vgWbf/sV8i3+F9
 MfVXufks1Z2OVVxy+t8refVBVoPilguufIxnAaXR+IvS3U5BZwYDVGxjTMopgZ9GQ2/xFnNGZwlr
 2OUDresZ30+jYtJuTOnr37hur3BQiPdl+R2YgU9fHQ+IjfgDjfDUUM8KpBHeEaKYakOpYwkDBbdN
@@ -72,15 +77,18 @@ fg72ur8CIXdiPgZOEBq9P3smOJmVIanhB9Jf7aGyeQu7AjNBMzWnN3Jlqsh763ZirIndckZoMGwX
 F2Tm1IHK6yESU5Jx3A12i/2V8cWpupTGrm/L+7SKDO+CqPVpYSmobBKcZUTrqWdNCbbTdXU/J2Pu
 8Eq5H069VCJHVIglyqX5YhhyUsDWpRIHtc3ljTJWbTo95QfguHhL4n0+nyUHs+/Dx+KDETvi0KkU
 6HyKQSPyPgjzaV+xwz92Q20sOBl+qGTCAanAFL9LjjfFV69uNzufHHIf80nvJC4BTvDb9pdU7+gY
-cm+4NfhasqddIj/uLm7yWw3NpzSQoeGML4UtaQ==</pre>
+cm+4NfhasqddIj/uLm7yWw3NpzSQoeGML4UtaQ==
+```
 
 **Generating a key pair**:
 
 A key pair in [PEM format](http://serverfault.com/questions/9708/what-is-a-pem-file-and-how-does-it-differ-from-other-openssl-generated-key-file) can be generated on Unix using [OpenSSL](https://www.openssl.org/docs/manmaster/man1/openssl-genrsa.html) on Unix:
 
-<pre>cd ~/.ssh
+```sh
+cd ~/.ssh
 openssl genrsa -out private_key.pem 2048
 chmod 600 private_key.pem
-openssl rsa -in private_key.pem -pubout > public_key.pem</pre>
+openssl rsa -in private_key.pem -pubout > public_key.pem
+```
 
 {% include navigation.html %}

--- a/docs/usage/encrypted-data-sets/operations/encrypt-file-with-AES-key.md
+++ b/docs/usage/encrypted-data-sets/operations/encrypt-file-with-AES-key.md
@@ -3,13 +3,18 @@
 This encrypts a plain-text file using a given MIME-encoded AES key.
 
 **Java class**:
- 
-    uk.ac.standrews.cs.util.dataset.encrypted.util.EncryptFileWithAESKey
- 
+
+```java
+uk.ac.standrews.cs.util.dataset.encrypted.util.EncryptFileWithAESKey
+```
+
 **Bash script**:
- 
-    src/main/scripts/encrypt-file-with-aes-key.sh <mime-encoded AES key> <path of plain-text file> <path of new encrypted file>
- 
-**Result**: encrypted file is written to specified path
+```sh
+src/main/scripts/encrypt-file-with-aes-key.sh <mime-encoded AES key> <path of plain-text file> <path of new encrypted file>
+```
+
+**Result**:
+
+Encrypted file is written to specified path
 
 {% include navigation.html %}

--- a/docs/usage/encrypted-data-sets/operations/encrypt-file-with-encrypted-AES-key.md
+++ b/docs/usage/encrypted-data-sets/operations/encrypt-file-with-encrypted-AES-key.md
@@ -1,18 +1,21 @@
 ## Operation: Encrypt File With Encrypted AES Key
 
-This encrypts a file using an AES key which is extracted from a file containing the key
-encrypted with a number of authorized public keys. Each of the encrypted keys is decrypted in turn 
-with this user's private key, until a valid AES key is extracted, which is then used to encrypt the 
-file.
+This encrypts a file using an AES key which is extracted from a file containing the key encrypted with a number of authorized public keys. Each of the encrypted keys is decrypted in turn with this user's private key, until a valid AES key is extracted, which is then used to encrypt the file.
 
 **Java class**:
- 
-    uk.ac.standrews.cs.util.dataset.encrypted.util.EncryptFileWithEncryptedAESKey
+
+```java
+uk.ac.standrews.cs.util.dataset.encrypted.util.EncryptFileWithEncryptedAESKey
+```
  
 **Bash script**:
- 
-    src/main/scripts/encrypt-file-with-encrypted-aes-key.sh <path of AES key encrypted for authorized users> <path of plain-text file> <path of new encrypted file>
 
-**Result**: encrypted file is written to specified path
+```sh
+src/main/scripts/encrypt-file-with-encrypted-aes-key.sh <path of AES key encrypted for authorized users> <path of plain-text file> <path of new encrypted file>
+```
+
+**Result**:
+
+Encrypted file is written to specified path
 
 {% include navigation.html %}

--- a/docs/usage/encrypted-data-sets/operations/generate-AES-key.md
+++ b/docs/usage/encrypted-data-sets/operations/generate-AES-key.md
@@ -4,12 +4,17 @@ This generates a new random MIME-encoded AES key.
 
 **Java class**:
 
-    uk.ac.standrews.cs.util.dataset.encrypted.util.GenerateAESKey
+``java
+uk.ac.standrews.cs.util.dataset.encrypted.util.GenerateAESKey
+```
 
 **Bash script**:
 
-    src/main/scripts/generate-aes-key.sh
+```sh
+src/main/scripts/generate-aes-key.sh
+```
+**Result**:
 
-**Result**: new key is printed to standard out
+New key is printed to standard out
 
 {% include navigation.html %}

--- a/docs/usage/encrypted-data-sets/operations/generate-and-encrypt-AES-key.md
+++ b/docs/usage/encrypted-data-sets/operations/generate-and-encrypt-AES-key.md
@@ -1,17 +1,21 @@
 ## Operation: Generate and Encrypt Random AES Key
 
-This generates a new random MIME-encoded AES key and encrypts it using public-key encryption. The AES key is encrypted separately with each of a
-number of authorized public keys read from a specified file. The resulting encrypted versions of the AES key are written
-to a given file.
+This generates a new random MIME-encoded AES key and encrypts it using public-key encryption. The AES key is encrypted separately with each of a number of authorized public keys read from a specified file. The resulting encrypted versions of the AES key are written to a given file.
 
 **Java class**:
 
-    uk.ac.standrews.cs.util.dataset.encrypted.util.GenerateAndEncryptAESKey
+```java
+uk.ac.standrews.cs.util.dataset.encrypted.util.GenerateAndEncryptAESKey
+```
 
 **Bash script**:
 
-    src/main/scripts/generate-and-encrypt-aes-key.sh <path of authorized public keys file> <path of AES key encrypted for authorized users>
+```sh
+src/main/scripts/generate-and-encrypt-aes-key.sh <path of authorized public keys file> <path of AES key encrypted for authorized users>
+```
 
-**Result**: file containing new encrypted versions of the key is written to specified path
+**Result**:
+
+File containing new encrypted versions of the key is written to specified path
 
 {% include navigation.html %}

--- a/docs/usage/encrypted-data-sets/operations/re-encrypt-AES-key.md
+++ b/docs/usage/encrypted-data-sets/operations/re-encrypt-AES-key.md
@@ -1,16 +1,20 @@
 ## Operation: Re-encrypt AES Key
 
-This regenerates encrypted versions of a previously generated AES key, to allow for authorized users being added or
-removed.
+This regenerates encrypted versions of a previously generated AES key, to allow for authorized users being added or removed.
 
 **Java class**:
 
-    uk.ac.standrews.cs.util.dataset.encrypted.util.ReEncryptAESKey
+```java
+uk.ac.standrews.cs.util.dataset.encrypted.util.ReEncryptAESKey
+```
 
 **Bash script**:
+```sh
+src/main/scripts/generate-aes-key.sh
+```
 
-    src/main/scripts/generate-aes-key.sh
+**Result**:
 
-**Result**: new key is printed to standard out
+New key is printed to standard out
 
 {% include navigation.html %}

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>ciesvium</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>ciesvium</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>ciesvium</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>ciesvium</name>
 

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
@@ -91,7 +91,7 @@ public class DataSet {
     @SuppressWarnings("WeakerAccess")
     public DataSet(final Path path) throws IOException {
 
-        this(path, Charset.defaultCharset());
+        this(FileManipulation.getInputStream(path), Charset.defaultCharset());
     }
 
     /**
@@ -116,7 +116,7 @@ public class DataSet {
      */
     public DataSet(final InputStream reader) {
 
-        this(reader, Charset.defaultCharset());
+        this(reader, DEFAULT_DELIMITER.charAt(0), Charset.defaultCharset());
     }
 
     /**
@@ -140,7 +140,7 @@ public class DataSet {
      */
     public DataSet(final InputStream reader, final char delimiter) {
 
-        this(reader, delimiter, Charset.defaultCharset());
+        this(reader, DEFAULT_CSV_FORMAT.builder().setDelimiter(delimiter).build(), Charset.defaultCharset());
     }
 
     /**

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
@@ -27,6 +27,7 @@ import uk.ac.standrews.cs.utilities.dataset.derived.Projector;
 import uk.ac.standrews.cs.utilities.dataset.derived.Selector;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -113,17 +114,31 @@ public class DataSet {
     }
 
     /**
-     * Creates a new dataset with column labels and data read from the given Reader, using a specified input format.
+     * Creates a new dataset with column labels and data read from the given
+     * Reader, using a specified input format.
      *
      * @param reader       the Reader to read column labels and data from
      * @param input_format the format
      */
     @SuppressWarnings("WeakerAccess")
     public DataSet(final InputStream reader, final CSVFormat input_format) {
+        this(reader, input_format, Charset.defaultCharset());
+    }
+
+    /**
+     * Creates a new dataset with column labels and data read from the given
+     * Reader, using a specified input format and charset.
+     *
+     * @param reader       the Reader to read column labels and data from
+     * @param input_format the format
+     * @param charset      the charset of the input data
+     */
+    @SuppressWarnings("WeakerAccess")
+    public DataSet(final InputStream reader, final CSVFormat input_format, Charset charset) {
 
         this();
 
-        try (final CSVParser parser = new CSVParser(new InputStreamReader(reader), input_format.withHeader())) {
+        try (final CSVParser parser = new CSVParser(new InputStreamReader(reader, charset), input_format.withHeader())) {
 
             labels.addAll(getColumnLabels(parser));
 

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
@@ -51,6 +51,12 @@ public class DataSet {
     public static final CSVFormat DEFAULT_CSV_FORMAT = CSVFormat.RFC4180;
 
     /**
+     * Charset to use for decoding input data.
+     */
+    @SuppressWarnings("WeakerAccess")
+    private static final Charset DEFAULT_CHARSET = Charset.defaultCharset();
+
+    /**
      * The default delimiter.
      */
     @SuppressWarnings("WeakerAccess")
@@ -92,7 +98,7 @@ public class DataSet {
     @SuppressWarnings("WeakerAccess")
     public DataSet(final Path path) throws IOException {
 
-        this(FileManipulation.getInputStream(path), Charset.defaultCharset());
+        this(FileManipulation.getInputStream(path));
     }
 
     /**
@@ -103,19 +109,7 @@ public class DataSet {
      */
     public DataSet(final InputStream reader) {
 
-        this(reader, DEFAULT_DELIMITER.charAt(0), Charset.defaultCharset());
-    }
-
-    /**
-     * Creates a new dataset with column labels and data read from the given
-     * Reader, using the default delimiter: {@value #DEFAULT_DELIMITER}.
-     *
-     * @param reader the Reader to read column labels and data from
-     * @param charset charset of the input stream data
-     */
-    public DataSet(final InputStream reader, final Charset charset) {
-
-        this(reader, DEFAULT_DELIMITER.charAt(0), charset);
+        this(reader, DEFAULT_DELIMITER.charAt(0));
     }
 
     /**
@@ -127,20 +121,7 @@ public class DataSet {
      */
     public DataSet(final InputStream reader, final char delimiter) {
 
-        this(reader, DEFAULT_CSV_FORMAT.builder().setDelimiter(delimiter).build(), Charset.defaultCharset());
-    }
-
-    /**
-     * Creates a new dataset with column labels and data read from the given
-     * Reader, using the default CSV input format and a specified delimiter.
-     *
-     * @param reader    the Reader to read column labels and data from
-     * @param delimiter the delimiter for labels and values
-     * @param charset   charset of the input stream data
-     */
-    public DataSet(final InputStream reader, final char delimiter, final Charset charset) {
-
-        this(reader, DEFAULT_CSV_FORMAT.builder().setDelimiter(delimiter).build(), charset);
+        this(reader, DEFAULT_CSV_FORMAT.builder().setDelimiter(delimiter).build());
     }
 
     /**
@@ -152,23 +133,10 @@ public class DataSet {
      */
     @SuppressWarnings("WeakerAccess")
     public DataSet(final InputStream reader, final CSVFormat input_format) {
-        this(reader, input_format, Charset.defaultCharset());
-    }
-
-    /**
-     * Creates a new dataset with column labels and data read from the given
-     * Reader, using a specified input format and charset.
-     *
-     * @param reader       the Reader to read column labels and data from
-     * @param input_format the format
-     * @param charset      the charset of the input data
-     */
-    @SuppressWarnings("WeakerAccess")
-    public DataSet(final InputStream reader, final CSVFormat input_format, Charset charset) {
 
         this();
 
-        try (final CSVParser parser = new CSVParser(new InputStreamReader(reader, charset), input_format.builder().setHeader().setSkipHeaderRecord(true).build())) {
+        try (final CSVParser parser = new CSVParser(new InputStreamReader(reader, getCharset()), input_format.builder().setHeader().setSkipHeaderRecord(true).build())) {
 
             labels.addAll(getColumnLabels(parser));
 
@@ -462,5 +430,9 @@ public class DataSet {
     private static boolean containsDuplicates(final List<String> strings) {
 
         return new HashSet<>(strings).size() < strings.size();
+    }
+
+    protected static Charset getCharset() {
+        return DEFAULT_CHARSET;
     }
 }

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
@@ -96,20 +96,6 @@ public class DataSet {
     }
 
     /**
-     * Creates a new dataset with column labels and data read from a file with
-     * the given path.
-     *
-     * @param path the path of the file to read column labels and data from
-     * @param charset charset of the input file
-     * @throws IOException if the file cannot be read
-     */
-    @SuppressWarnings("WeakerAccess")
-    public DataSet(final Path path, Charset charset) throws IOException {
-
-        this(FileManipulation.getInputStream(path), charset);
-    }
-
-    /**
      * Creates a new dataset with column labels and data read from the given
      * Reader, using the default delimiter: {@value #DEFAULT_DELIMITER}.
      *

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
@@ -110,7 +110,7 @@ public class DataSet {
      */
     public DataSet(final InputStream reader, final char delimiter) {
 
-        this(reader, DEFAULT_CSV_FORMAT.withDelimiter(delimiter));
+        this(reader, DEFAULT_CSV_FORMAT.builder().setDelimiter(delimiter).build());
     }
 
     /**
@@ -138,7 +138,7 @@ public class DataSet {
 
         this();
 
-        try (final CSVParser parser = new CSVParser(new InputStreamReader(reader, charset), input_format.withHeader())) {
+        try (final CSVParser parser = new CSVParser(new InputStreamReader(reader, charset), input_format.builder().setHeader().setSkipHeaderRecord(true).build())) {
 
             labels.addAll(getColumnLabels(parser));
 
@@ -286,7 +286,7 @@ public class DataSet {
     public void print(final Appendable out) throws IOException {
 
         final String[] header_array = labels.toArray(new String[0]);
-        @SuppressWarnings("resource") final CSVPrinter printer = new CSVPrinter(out, output_format.withHeader(header_array));
+        @SuppressWarnings("resource") final CSVPrinter printer = new CSVPrinter(out, output_format.builder().setHeader(header_array).build());
 
         for (final List<String> record : records) {
 

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
@@ -35,8 +35,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Simple abstraction over a plain-text dataset. Data is represented as a list of rows, each of which is a list of strings, plus
- * a list of string column labels.
+ * Simple abstraction over a plain-text dataset. Data is represented as a list
+ * of rows, each of which is a list of strings, plus a list of string column
+ * labels.
  *
  * @author Graham Kirby (graham.kirby@st-andrews.ac.uk)
  */
@@ -81,7 +82,8 @@ public class DataSet {
     }
 
     /**
-     * Creates a new dataset with column labels and data read from a file with the given path.
+     * Creates a new dataset with column labels and data read from a file with
+     * the given path.
      *
      * @param path the path of the file to read column labels and data from
      * @throws IOException if the file cannot be read
@@ -89,28 +91,69 @@ public class DataSet {
     @SuppressWarnings("WeakerAccess")
     public DataSet(final Path path) throws IOException {
 
-        this(FileManipulation.getInputStream(path));
+        this(path, Charset.defaultCharset());
     }
 
     /**
-     * Creates a new dataset with column labels and data read from the given Reader, using the default delimiter: {@value #DEFAULT_DELIMITER}.
+     * Creates a new dataset with column labels and data read from a file with
+     * the given path.
+     *
+     * @param path the path of the file to read column labels and data from
+     * @param charset the charset to use
+     * @throws IOException if the file cannot be read
+     */
+    @SuppressWarnings("WeakerAccess")
+    public DataSet(final Path path, Charset charset) throws IOException {
+
+        this(FileManipulation.getInputStream(path), charset);
+    }
+
+    /**
+     * Creates a new dataset with column labels and data read from the given
+     * Reader, using the default delimiter: {@value #DEFAULT_DELIMITER}.
      *
      * @param reader the Reader to read column labels and data from
      */
     public DataSet(final InputStream reader) {
 
-        this(reader, DEFAULT_DELIMITER.charAt(0));
+        this(reader, Charset.defaultCharset());
     }
 
     /**
-     * Creates a new dataset with column labels and data read from the given Reader, using the default CSV input format and a specified delimiter.
+     * Creates a new dataset with column labels and data read from the given
+     * Reader, using the default delimiter: {@value #DEFAULT_DELIMITER}.
+     *
+     * @param reader the Reader to read column labels and data from
+     * @param charset charset to use
+     */
+    public DataSet(final InputStream reader, final Charset charset) {
+
+        this(reader, DEFAULT_DELIMITER.charAt(0), charset);
+    }
+
+    /**
+     * Creates a new dataset with column labels and data read from the given
+     * Reader, using the default CSV input format and a specified delimiter.
      *
      * @param reader    the Reader to read column labels and data from
      * @param delimiter the delimiter for labels and values
      */
     public DataSet(final InputStream reader, final char delimiter) {
 
-        this(reader, DEFAULT_CSV_FORMAT.builder().setDelimiter(delimiter).build());
+        this(reader, delimiter, Charset.defaultCharset());
+    }
+
+    /**
+     * Creates a new dataset with column labels and data read from the given
+     * Reader, using the default CSV input format and a specified delimiter.
+     *
+     * @param reader    the Reader to read column labels and data from
+     * @param delimiter the delimiter for labels and values
+     * @param charset   the charset to use
+     */
+    public DataSet(final InputStream reader, final char delimiter, final Charset charset) {
+
+        this(reader, DEFAULT_CSV_FORMAT.builder().setDelimiter(delimiter).build(), charset);
     }
 
     /**

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
@@ -44,7 +44,8 @@ import java.util.stream.Collectors;
 public class DataSet {
 
     /**
-     * The default CSV file format: <a href="https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.html#RFC4180">RFC4180</a>.
+     * The default CSV file format:
+     * <a href="https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.html#RFC4180">RFC4180</a>.
      */
     @SuppressWarnings("WeakerAccess")
     public static final CSVFormat DEFAULT_CSV_FORMAT = CSVFormat.RFC4180;
@@ -99,7 +100,7 @@ public class DataSet {
      * the given path.
      *
      * @param path the path of the file to read column labels and data from
-     * @param charset the charset to use
+     * @param charset charset of the input file
      * @throws IOException if the file cannot be read
      */
     @SuppressWarnings("WeakerAccess")
@@ -124,7 +125,7 @@ public class DataSet {
      * Reader, using the default delimiter: {@value #DEFAULT_DELIMITER}.
      *
      * @param reader the Reader to read column labels and data from
-     * @param charset charset to use
+     * @param charset charset of the input stream data
      */
     public DataSet(final InputStream reader, final Charset charset) {
 
@@ -149,7 +150,7 @@ public class DataSet {
      *
      * @param reader    the Reader to read column labels and data from
      * @param delimiter the delimiter for labels and values
-     * @param charset   the charset to use
+     * @param charset   charset of the input stream data
      */
     public DataSet(final InputStream reader, final char delimiter, final Charset charset) {
 
@@ -202,7 +203,8 @@ public class DataSet {
     }
 
     /**
-     * Creates a new dataset from this dataset, with the same column labels and selected rows.
+     * Creates a new dataset from this dataset, with the same column labels and
+     * selected rows.
      *
      * @param selector a selector to determine which rows should be included
      * @return the new dataset
@@ -216,7 +218,8 @@ public class DataSet {
     /**
      * Creates a new dataset from this dataset, with specified columns.
      *
-     * @param projector a projector to determine which columns should be included
+     * @param projector a projector to determine which columns should be
+     *                  included
      * @return the new dataset
      */
     @SuppressWarnings("WeakerAccess")
@@ -226,9 +229,11 @@ public class DataSet {
     }
 
     /**
-     * Creates a new dataset from this dataset, with each row transformed in a specified way.
+     * Creates a new dataset from this dataset, with each row transformed in a
+     * specified way.
      *
-     * @param mapper a mapper to transform each row into a new row in the output dataset
+     * @param mapper a mapper to transform each row into a new row in the output
+     *               dataset
      * @return the new dataset
      */
     @SuppressWarnings("unused")
@@ -238,9 +243,11 @@ public class DataSet {
     }
 
     /**
-     * Creates a new dataset from this dataset, with additional generated columns.
+     * Creates a new dataset from this dataset, with additional generated
+     * columns.
      *
-     * @param extender an extender to generate additional column labels and values
+     * @param extender an extender to generate additional column labels and
+     *                 values
      * @return the new dataset
      */
     @SuppressWarnings("unused")
@@ -294,7 +301,7 @@ public class DataSet {
      * Gets the value for a specified column label, from a given record.
      *
      * @param record the record
-     * @param label  the label of the required column
+     * @param label the label of the required column
      * @return the value of the column for the record
      * @throws RuntimeException if the specified label is not present
      */
@@ -324,7 +331,8 @@ public class DataSet {
      * Prints this dataset to the given output object.
      *
      * @param out the output object
-     * @throws IOException if this dataset cannot be printed to the given output object
+     * @throws IOException if this dataset cannot be printed to the given output
+     *                     object.
      */
     public void print(final Appendable out) throws IOException {
 

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/DerivedDataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/DerivedDataSet.java
@@ -25,7 +25,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Abstract superclass for datasets derived from existing datasets via a sequence of relational-style transformations.
+ * Abstract superclass for datasets derived from existing datasets via a
+ * sequence of relational-style transformations.
  *
  * @author Graham Kirby (graham.kirby@st-andrews.ac.uk)
  */

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Extender.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Extender.java
@@ -28,12 +28,14 @@ import java.util.List;
 public interface Extender {
 
     /**
-     * Gets the additional values to be appended to a given record. The containing dataset is also
-     * made available in case the extender logic needs access to the column labels.
+     * Gets the additional values to be appended to a given record. The containing
+     * dataset is also made available in case the extender logic needs access to
+     * the column labels.
      *
      * @param record   the existing record
      * @param data_set the dataset within which the record occurs
-     * @return a list of new values to be appended to the record in the extended dataset
+     * @return a list of new values to be appended to the record in the extended
+     * dataset
      */
     @SuppressWarnings("UnusedDeclaration")
     List<String> getAdditionalValues(List<String> record, DataSet data_set);

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Mapper.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Mapper.java
@@ -16,8 +16,6 @@
  */
 package uk.ac.standrews.cs.utilities.dataset.derived;
 
-import uk.ac.standrews.cs.utilities.dataset.DataSet;
-
 import java.util.List;
 
 /**

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Mapper.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Mapper.java
@@ -30,7 +30,8 @@ public interface Mapper {
      * Creates a new record based on an existing record.
      *
      * @param record   the existing record
-     * @param labels the column labels for the dataset within which the record occurs
+     * @param labels the column labels for the dataset within which the record
+     * occurs
      * @return a new record based on the existing record
      */
     List<String> mapRecord(List<String> record, List<String> labels);

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Selector.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Selector.java
@@ -28,8 +28,9 @@ import java.util.List;
 public interface Selector {
 
     /**
-     * Determines whether a given record should be selected. The containing dataset is also
-     * made available in case the selection logic needs access to the column labels.
+     * Determines whether a given record should be selected. The containing
+     * dataset is also made available in case the selection logic needs access
+     * to the column labels.
      *
      * @param record   the record to be considered
      * @param data_set the dataset within which the record occurs

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
@@ -29,15 +29,16 @@ import java.nio.file.Path;
 import java.util.List;
 
 /**
- * Version of dataset that allows the persistent form to be encrypted. A dataset can be instantiated from encrypted
- * data, or output in encrypted form.
+ * Version of dataset that allows the persistent form to be encrypted. A dataset
+ * can be instantiated from encrypted data, or output in encrypted form.
  *
  * @author Graham Kirby (graham.kirby@st-andrews.ac.uk)
  */
 public class EncryptedDataSet extends DataSet {
 
     /**
-     * Creates a new dataset with column labels and data read from a file with the given path.
+     * Creates a new dataset with column labels and data read from a file with
+     * the given path.
      *
      * @param path the path of the file to read column labels and data from
      * @throws IOException if the file cannot be read
@@ -48,9 +49,23 @@ public class EncryptedDataSet extends DataSet {
     }
 
     /**
+     * Creates a new dataset with column labels and data read from a file with
+     * the given path.
+     *
+     * @param path              the path of the file to read column labels and
+     *                          data from
+     * @param charset           the charset of the input file
+     * @throws IOException      if the file cannot be read
+     */
+    public EncryptedDataSet(final Path path, final Charset charset) throws IOException {
+
+        super(path, charset);
+    }
+
+    /**
      * Creates a new empty dataset with given column labels.
      *
-     * @param labels the column labels
+     * @param labels            the column labels
      */
     public EncryptedDataSet(final List<String> labels) {
 
@@ -60,7 +75,7 @@ public class EncryptedDataSet extends DataSet {
     /**
      * Creates a new dataset containing a copy of the given dataset.
      *
-     * @param existing_records the dataset to copy
+     * @param existing_records  the dataset to copy
      */
     public EncryptedDataSet(final DataSet existing_records) {
 
@@ -70,40 +85,73 @@ public class EncryptedDataSet extends DataSet {
     /**
      * Creates a new dataset from an encrypted input stream.
      *
-     * @param source_data the encrypted data input stream
-     * @param AES_key     the AES key to decrypt the input stream
-     * @throws CryptoException if data cannot be read from the input stream, or the data cannot be decrypted with the given key
-     * @throws IOException     if an IOError occurs when auto-closing streams
+     * @param source_data       the encrypted data input stream
+     * @param AES_key           the AES key to decrypt the input stream
+     * @param charset           charset of the input stream data
+     * @throws CryptoException  if data cannot be read from the input stream, or
+     *                          the data cannot be decrypted with the given key
+     * @throws IOException      if an IOError occurs when auto-closing streams
      */
-    public EncryptedDataSet(final InputStream source_data, final SecretKey AES_key) throws CryptoException, IOException {
+    public EncryptedDataSet(final InputStream source_data, final SecretKey AES_key, Charset charset) throws CryptoException, IOException {
 
         try (InputStream in = source_data) {
-             init(decrypt(source_data, AES_key));
+            init(decrypt(source_data, AES_key, charset));
         }
+    }
+
+        /**
+     * Creates a new dataset from an encrypted input stream.
+     *
+     * @param source_data       the encrypted data input stream
+     * @param AES_key           the AES key to decrypt the input stream
+     * @throws CryptoException  if data cannot be read from the input stream, or
+     *                          the data cannot be decrypted with the given key
+     * @throws IOException      if an IOError occurs when auto-closing streams
+     */
+    public EncryptedDataSet(final InputStream source_data, final SecretKey AES_key) throws CryptoException, IOException {
+        this(source_data, AES_key, Charset.defaultCharset());
     }
 
     /**
      * Creates a new dataset from an encrypted file.
      *
-     * @param path    the path of the encrypted file
-     * @param AES_key the AES key to decrypt the file
-     * @throws CryptoException if the data cannot be decrypted with the given key
-     * @throws IOException     if data cannot be read from the file
+     * @param path              the path of the encrypted file
+     * @param AES_key           the AES key to decrypt the file
+     * @param charset           charset of the input file
+     * @throws CryptoException  if the data cannot be decrypted with the given key
+     * @throws IOException      if data cannot be read from the file
      */
-    public EncryptedDataSet(final Path path, final SecretKey AES_key) throws CryptoException, IOException {
+    public EncryptedDataSet(final Path path, final SecretKey AES_key, Charset charset) throws CryptoException, IOException {
 
-        this(Files.newInputStream(path), AES_key);
+        this(Files.newInputStream(path), AES_key, charset);
     }
 
     /**
-     * Creates a new dataset from an encrypted input stream. This constructor attempts to extract the MIME-encoded AES key
-     * from the given input stream, which contains versions of the AES key encrypted with various users' RSA public
-     * keys.
+     * Creates a new dataset from an encrypted file.
      *
-     * @param source_data          the encrypted data input stream
-     * @param encrypted_key_stream an input stream containing versions of the MIME-encoded AES key encrypted with various users' public keys
-     * @throws CryptoException if the AES key cannot be extracted with this user's private key
-     * @throws IOException     if either input stream cannot be read
+     * @param path              the path of the encrypted file
+     * @param AES_key           the AES key to decrypt the file
+     * @throws CryptoException  if the data cannot be decrypted with the given key
+     * @throws IOException      if data cannot be read from the file
+     */
+    public EncryptedDataSet(final Path path, final SecretKey AES_key) throws CryptoException, IOException {
+
+        this(Files.newInputStream(path), AES_key, Charset.defaultCharset());
+    }
+
+    /**
+     * Creates a new dataset from an encrypted input stream. This constructor
+     * attempts to extract the MIME-encoded AES key from the given input stream,
+     * which contains versions of the AES key encrypted with various users' RSA
+     * public keys.
+     *
+     * @param source_data           the encrypted data input stream
+     * @param encrypted_key_stream  an input stream containing versions of the 
+     *                              MIME-encoded AES key encrypted with various
+     *                              users' public keys
+     * @throws CryptoException      if the AES key cannot be extracted with this
+     *                              user's private key
+     * @throws IOException          if either input stream cannot be read
      */
     @SuppressWarnings("UnusedDeclaration")
     public EncryptedDataSet(final InputStream source_data, final InputStream encrypted_key_stream) throws IOException, CryptoException {
@@ -114,10 +162,11 @@ public class EncryptedDataSet extends DataSet {
     /**
      * Prints this dataset, in encrypted form, to the given output object.
      *
-     * @param out     the output object
-     * @param AES_key the AES key to encrypt the dataset
-     * @throws IOException     if this dataset cannot be printed to the given output object
-     * @throws CryptoException if the data cannot be encrypted
+     * @param out               the output object
+     * @param AES_key           the AES key to encrypt the dataset
+     * @throws IOException      if this dataset cannot be printed to the given
+     *                          output object
+     * @throws CryptoException  if the data cannot be encrypted
      */
     @SuppressWarnings("WeakerAccess")
     public void print(final Appendable out, final SecretKey AES_key) throws IOException, CryptoException {
@@ -132,10 +181,11 @@ public class EncryptedDataSet extends DataSet {
     /**
      * Prints this dataset, in encrypted form, to the given file.
      *
-     * @param path    the path of the output file
-     * @param AES_key the AES key to encrypt the dataset
-     * @throws IOException     if this dataset cannot be printed to the given output object
-     * @throws CryptoException if the data cannot be encrypted
+     * @param path              the path of the output file
+     * @param AES_key           the AES key to encrypt the dataset
+     * @throws IOException      if this dataset cannot be printed to the given
+     *                          output object
+     * @throws CryptoException  if the data cannot be encrypted
      */
     public void print(final Path path, final SecretKey AES_key) throws IOException, CryptoException {
 
@@ -154,11 +204,6 @@ public class EncryptedDataSet extends DataSet {
                 out.append((char) b);
             }
         };
-    }
-
-    private static DataSet decrypt(final InputStream source_data, final SecretKey AES_key) throws CryptoException {
-        
-        return decrypt(source_data, AES_key, Charset.defaultCharset());
     }
 
     private static DataSet decrypt(final InputStream source_data, final SecretKey AES_key, final Charset charset) throws CryptoException {

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
@@ -23,6 +23,7 @@ import uk.ac.standrews.cs.utilities.dataset.DataSet;
 
 import javax.crypto.SecretKey;
 import java.io.*;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -75,10 +76,10 @@ public class EncryptedDataSet extends DataSet {
      * @throws IOException     if an IOError occurs when auto-closing streams
      */
     public EncryptedDataSet(final InputStream source_data, final SecretKey AES_key) throws CryptoException, IOException {
+
         try (InputStream in = source_data) {
              init(decrypt(source_data, AES_key));
         }
-       
     }
 
     /**
@@ -156,10 +157,15 @@ public class EncryptedDataSet extends DataSet {
     }
 
     private static DataSet decrypt(final InputStream source_data, final SecretKey AES_key) throws CryptoException {
+        
+        return decrypt(source_data, AES_key, Charset.defaultCharset());
+    }
+
+    private static DataSet decrypt(final InputStream source_data, final SecretKey AES_key, final Charset charset) throws CryptoException {
 
         final ByteArrayOutputStream output_stream = new ByteArrayOutputStream();
         SymmetricEncryption.decrypt(AES_key, source_data, output_stream);
 
-        return new DataSet(new ByteArrayInputStream(output_stream.toByteArray()));
+        return new DataSet(new ByteArrayInputStream(output_stream.toByteArray()), charset);
     }
 }

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
@@ -72,10 +72,13 @@ public class EncryptedDataSet extends DataSet {
      * @param source_data the encrypted data input stream
      * @param AES_key     the AES key to decrypt the input stream
      * @throws CryptoException if data cannot be read from the input stream, or the data cannot be decrypted with the given key
+     * @throws IOException     if an IOError occurs when auto-closing streams
      */
-    public EncryptedDataSet(final InputStream source_data, final SecretKey AES_key) throws CryptoException {
-
-        init(decrypt(source_data, AES_key));
+    public EncryptedDataSet(final InputStream source_data, final SecretKey AES_key) throws CryptoException, IOException {
+        try (InputStream in = source_data) {
+             init(decrypt(source_data, AES_key));
+        }
+       
     }
 
     /**
@@ -88,9 +91,7 @@ public class EncryptedDataSet extends DataSet {
      */
     public EncryptedDataSet(final Path path, final SecretKey AES_key) throws CryptoException, IOException {
 
-        try (final InputStream input_stream = Files.newInputStream(path)) {
-            init(decrypt(input_stream, AES_key));
-        }
+        this(Files.newInputStream(path), AES_key);
     }
 
     /**
@@ -106,9 +107,7 @@ public class EncryptedDataSet extends DataSet {
     @SuppressWarnings("UnusedDeclaration")
     public EncryptedDataSet(final InputStream source_data, final InputStream encrypted_key_stream) throws IOException, CryptoException {
 
-        final SecretKey AES_key = AsymmetricEncryption.getAESKey(encrypted_key_stream);
-
-        init(decrypt(source_data, AES_key));
+        this(source_data, AsymmetricEncryption.getAESKey(encrypted_key_stream));
     }
 
     /**

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
@@ -23,7 +23,6 @@ import uk.ac.standrews.cs.utilities.dataset.DataSet;
 
 import javax.crypto.SecretKey;
 import java.io.*;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -46,20 +45,6 @@ public class EncryptedDataSet extends DataSet {
     public EncryptedDataSet(final Path path) throws IOException {
 
         super(path);
-    }
-
-    /**
-     * Creates a new dataset with column labels and data read from a file with
-     * the given path.
-     *
-     * @param path              the path of the file to read column labels and
-     *                          data from
-     * @param charset           the charset of the input file
-     * @throws IOException      if the file cannot be read
-     */
-    public EncryptedDataSet(final Path path, final Charset charset) throws IOException {
-
-        super(path, charset);
     }
 
     /**
@@ -87,43 +72,15 @@ public class EncryptedDataSet extends DataSet {
      *
      * @param source_data       the encrypted data input stream
      * @param AES_key           the AES key to decrypt the input stream
-     * @param charset           charset of the input stream data
-     * @throws CryptoException  if data cannot be read from the input stream, or
-     *                          the data cannot be decrypted with the given key
-     * @throws IOException      if an IOError occurs when auto-closing streams
-     */
-    public EncryptedDataSet(final InputStream source_data, final SecretKey AES_key, Charset charset) throws CryptoException, IOException {
-
-        try (InputStream in = source_data) {
-            init(decrypt(source_data, AES_key, charset));
-        }
-    }
-
-        /**
-     * Creates a new dataset from an encrypted input stream.
-     *
-     * @param source_data       the encrypted data input stream
-     * @param AES_key           the AES key to decrypt the input stream
      * @throws CryptoException  if data cannot be read from the input stream, or
      *                          the data cannot be decrypted with the given key
      * @throws IOException      if an IOError occurs when auto-closing streams
      */
     public EncryptedDataSet(final InputStream source_data, final SecretKey AES_key) throws CryptoException, IOException {
-        this(source_data, AES_key, Charset.defaultCharset());
-    }
 
-    /**
-     * Creates a new dataset from an encrypted file.
-     *
-     * @param path              the path of the encrypted file
-     * @param AES_key           the AES key to decrypt the file
-     * @param charset           charset of the input file
-     * @throws CryptoException  if the data cannot be decrypted with the given key
-     * @throws IOException      if data cannot be read from the file
-     */
-    public EncryptedDataSet(final Path path, final SecretKey AES_key, Charset charset) throws CryptoException, IOException {
-
-        this(Files.newInputStream(path), AES_key, charset);
+        try (InputStream in = source_data) {
+            init(decrypt(source_data, AES_key));
+        }
     }
 
     /**
@@ -136,7 +93,7 @@ public class EncryptedDataSet extends DataSet {
      */
     public EncryptedDataSet(final Path path, final SecretKey AES_key) throws CryptoException, IOException {
 
-        this(Files.newInputStream(path), AES_key, Charset.defaultCharset());
+        this(Files.newInputStream(path), AES_key);
     }
 
     /**
@@ -206,11 +163,11 @@ public class EncryptedDataSet extends DataSet {
         };
     }
 
-    private static DataSet decrypt(final InputStream source_data, final SecretKey AES_key, final Charset charset) throws CryptoException {
+    private static DataSet decrypt(final InputStream source_data, final SecretKey AES_key) throws CryptoException {
 
         final ByteArrayOutputStream output_stream = new ByteArrayOutputStream();
         SymmetricEncryption.decrypt(AES_key, source_data, output_stream);
 
-        return new DataSet(new ByteArrayInputStream(output_stream.toByteArray()), charset);
+        return new DataSet(new ByteArrayInputStream(output_stream.toByteArray()));
     }
 }

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/examples/SymmetricallyEncryptedDataset.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/examples/SymmetricallyEncryptedDataset.java
@@ -71,9 +71,12 @@ public class SymmetricallyEncryptedDataset {
 
     private void testDataSetUsingResources() throws IOException, CryptoException {
 
-        // Assume that encrypted dataset has already been created and copied into resources tree.
+        /* 
+         * Assume that encrypted dataset has already been created and copied
+         * into resources tree. Key string previously created using
+         * generate-AES-key.
+         */
 
-        // Key string previously created using generate-AES-key.
         final SecretKey key = SymmetricEncryption.getKey("L8rWNo0uZ+rBsTP08DR4Mw==");
 
         final InputStream input_stream = getClass().getResourceAsStream("cipher_text.txt");

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/DecryptAESKey.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/DecryptAESKey.java
@@ -25,8 +25,8 @@ import java.io.IOException;
 import java.nio.file.Paths;
 
 /**
- * Extracts an AES key from a file containing the key encrypted separately with the public key
- * of each authorized user.
+ * Extracts an AES key from a file containing the key encrypted separately with
+ * the public key of each authorized user.
  *
  * @author Graham Kirby (graham.kirby@st-andrews.ac.uk)
  */
@@ -34,12 +34,13 @@ import java.nio.file.Paths;
 public class DecryptAESKey {
 
     /**
-     * Extracts a MIME-encoded AES key from a file containing the key encrypted separately with the public key
-     * of each authorized user.
+     * Extracts a MIME-encoded AES key from a file containing the key encrypted
+     * separately with the public key of each authorized user.
      *
-     * @param args path of file containing encrypted key, path of plain-text file, path of new encrypted file
+     * @param args path of file containing encrypted key, path of plain-text
+     * file, path of new encrypted file.
      * @throws CryptoException if the encryption cannot be completed
-     * @throws IOException     if a file cannot be accessed
+     * @throws IOException if a file cannot be accessed
      */
     public static void main(String[] args) throws CryptoException, IOException {
 

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/DecryptFileWithAESKey.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/DecryptFileWithAESKey.java
@@ -33,9 +33,10 @@ public class DecryptFileWithAESKey {
     /**
      * Decrypts a file with a given AES key.
      *
-     * @param args MIME-encoded AES key, path of encrypted file, path of new plain-text file
+     * @param args MIME-encoded AES key, path of encrypted file, path of new
+     * plain-text file.
      * @throws CryptoException if the decryption cannot be completed
-     * @throws IOException     if a file cannot be accessed
+     * @throws IOException if a file cannot be accessed
      */
     public static void main(String[] args) throws CryptoException, IOException {
 

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/DecryptFileWithEncryptedAESKey.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/DecryptFileWithEncryptedAESKey.java
@@ -33,12 +33,13 @@ import java.nio.file.Paths;
 public class DecryptFileWithEncryptedAESKey {
 
     /**
-     * Decrypts a file with an AES key extracted from a file containing the key encrypted separately with the public key
-     * of each authorized user.
+     * Decrypts a file with an AES key extracted from a file containing the key
+     * encrypted separately with the public key of each authorized user.
      *
-     * @param args path of file containing encrypted key, path of encrypted file, path of new plain-text file
+     * @param args path of file containing encrypted key, path of encrypted file,
+     * path of new plain-text file
      * @throws CryptoException if the encryption cannot be completed
-     * @throws IOException     if a file cannot be accessed
+     * @throws IOException if a file cannot be accessed
      */
     public static void main(String[] args) throws CryptoException, IOException {
 

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/EncryptAESKey.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/EncryptAESKey.java
@@ -32,9 +32,11 @@ import java.nio.file.Paths;
 public class EncryptAESKey {
 
     /**
-     * Encrypts a MIME-encoded key separately with each of a number of public keys.
+     * Encrypts a MIME-encoded key separately with each of a number of public
+     * keys.
      *
-     * @param args MIME-encoded AES key, path of file containing public keys, path of new file containing encrypted keys
+     * @param args MIME-encoded AES key, path of file containing public keys,
+     * path of new file containing encrypted keys
      * @throws CryptoException if the encryption cannot be completed
      * @throws IOException     if a file cannot be accessed
      */

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/EncryptFileWithAESKey.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/EncryptFileWithAESKey.java
@@ -33,7 +33,8 @@ public class EncryptFileWithAESKey {
     /**
      * Encrypts a file with a given AES key.
      *
-     * @param args MIME-encoded AES key, path of plain-text file, path of new encrypted file
+     * @param args MIME-encoded AES key, path of plain-text file, path of new
+     * encrypted file
      * @throws CryptoException if the encryption cannot be completed
      * @throws IOException     if a file cannot be accessed
      */

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/EncryptFileWithEncryptedAESKey.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/EncryptFileWithEncryptedAESKey.java
@@ -33,10 +33,11 @@ import java.nio.file.Paths;
 public class EncryptFileWithEncryptedAESKey {
 
     /**
-     * Encrypts a file with an AES key extracted from a file containing the key encrypted separately with the public key
-     * of each authorized user.
+     * Encrypts a file with an AES key extracted from a file containing the key
+     * encrypted separately with the public key of each authorized user.
      *
-     * @param args path of file containing encrypted key, path of plain-text file, path of new encrypted file
+     * @param args path of file containing encrypted key, path of plain-text
+     * file, path of new encrypted file
      * @throws CryptoException if the encryption cannot be completed
      * @throws IOException     if a file cannot be accessed
      */

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/GenerateAndEncryptAESKey.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/GenerateAndEncryptAESKey.java
@@ -32,9 +32,11 @@ import java.nio.file.Paths;
 public class GenerateAndEncryptAESKey {
 
     /**
-     * Generates a MIME-encoded key and encrypts it separately with each of a number of public keys.
+     * Generates a MIME-encoded key and encrypts it separately with each of a
+     * number of public keys.
      *
-     * @param args MIME-encoded AES key, path of file containing public keys, path of new file containing encrypted keys
+     * @param args MIME-encoded AES key, path of file containing public keys, 
+     * path of new file containing encrypted keys
      * @throws CryptoException if the encryption cannot be completed
      * @throws IOException     if a file cannot be accessed
      */

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/ReEncryptAESKey.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/util/ReEncryptAESKey.java
@@ -24,7 +24,8 @@ import java.io.IOException;
 import java.nio.file.Paths;
 
 /**
- * Re-encrypts a previously encrypted symmetric key with a new list of public keys.
+ * Re-encrypts a previously encrypted symmetric key with a new list of public
+ * keys.
  *
  * @author Graham Kirby (graham.kirby@st-andrews.ac.uk)
  */
@@ -32,9 +33,12 @@ import java.nio.file.Paths;
 public class ReEncryptAESKey {
 
     /**
-     * Encrypts a previously encrypted AES key separately with each of a number of public keys, and over-writes the file of encrypted versions of the AES key.
+     * Encrypts a previously encrypted AES key separately with each of a number
+     * of public keys, and over-writes the file of encrypted versions of the AES
+     * key.
      *
-     * @param args path of file containing public keys, path of file containing encrypted keys to be updated
+     * @param args path of file containing public keys, path of file containing
+     * encrypted keys to be updated
      * @throws CryptoException if the encryption cannot be completed
      * @throws IOException     if a file cannot be accessed
      */

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/ConfidenceIntervals.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/ConfidenceIntervals.java
@@ -21,7 +21,8 @@ import uk.ac.standrews.cs.utilities.Statistics;
 import java.util.List;
 
 /**
- * Class to calculate confidence intervals for values within columns in a rectangular numerical table.
+ * Class to calculate confidence intervals for values within columns in a
+ * rectangular numerical table.
  *
  * @author Graham Kirby (graham.kirby@st-andrews.ac.uk)
  */

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/TableGenerator.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/TableGenerator.java
@@ -23,13 +23,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Class to generate a table summarising a set of datasets, intended for combining results from multiple runs
- * of an experiment.
- * <p>
- * Each dataset is expected to have the same column headings, and numerical data in the rows.
- * The summary table contains the same column labels as the input datasets, and a row for each dataset.
- * The value at each position gives the mean and confidence interval of the values in that column for
- * the corresponding dataset.
+ * Class to generate a table summarising a set of datasets, intended for
+ * combining results from multiple runs of an experiment.
+ * 
+ * Each dataset is expected to have the same column headings, and numerical data
+ * in the rows. The summary table contains the same column labels as the input
+ * datasets, and a row for each dataset.
+ * 
+ * The value at each position gives the mean and confidence interval of the
+ * values in that column for the corresponding dataset.
  *
  * @author Graham Kirby (graham.kirby@st-andrews.ac.uk)
  */
@@ -45,9 +47,14 @@ public class TableGenerator {
      * Creates a new table generator.
      *
      * @param data_sets             the datasets to be summarised
-     * @param first_column_heading  the heading for the first column of the resulting table
-     * @param row_labels            the labels to be used in the remainder of the first column of the resulting table
-     * @param display_as_percentage a list of booleans, one per column in the input datasets, indicating whether the corresponding value should be displayed as a percentage
+     * @param first_column_heading  the heading for the first column of the
+     *                              resulting table.
+     * @param row_labels            the labels to be used in the remainder of 
+     *                              the first column of the resulting table.
+     * @param display_as_percentage a list of booleans, one per column in the
+     *                              input datasets, indicating whether the
+     *                              corresponding value should be displayed as a
+     *                              percentage.
      */
     @SuppressWarnings("UnusedDeclaration")
     public TableGenerator(List<DataSet> data_sets, String first_column_heading, List<String> row_labels, List<Boolean> display_as_percentage) {
@@ -95,8 +102,13 @@ public class TableGenerator {
     @SuppressWarnings("UnusedDeclaration")
     public DataSet getTable() {
 
-        // Get the column labels from the data set for the first row - all rows should have the same labels.
-        // Construct a new array list for column labels since DataSet#getColumnLabels() returns an unmodifiable list.
+        /*
+         * Get the column labels from the data set for the first row - all rows
+         * should have the same labels.
+         * 
+         * Construct a new array list for column labels since
+         * DataSet#getColumnLabels() returns an unmodifiable list.
+         */
         List<String> column_labels = new ArrayList<>(data_sets.get(0).getColumnLabels());
         column_labels.add(0, first_column_heading);
 

--- a/src/test/java/uk/ac/standrews/cs/utilities/dataset/DataSetErrorTest.java
+++ b/src/test/java/uk/ac/standrews/cs/utilities/dataset/DataSetErrorTest.java
@@ -19,7 +19,6 @@ package uk.ac.standrews.cs.utilities.dataset;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 public class DataSetErrorTest {
 


### PR DESCRIPTION
## Overview
Introduces the option for explicitly setting an input charset for `DataSet` and it's child classes. Also includes several small updates throughout the repository, replaced deprecated functions, updating build workflow to use Java 21, and improvements to documentation.

Closes #2 , closes #3 , closes #4 
## Changelist
**Features:**
- Implemented `getCharset` function in `DataSet` which is used when parsing input data, which can be overridden by a child class if an encoding more specific than system-default is required.

**Refactoring:**
- Removes unused imports.
- Replaces uses of deprecated `CSVFormat` functions in `DataSet` with more modern `CSVFormat.builder()` functions.
- Reformatted JavaDoc comments in `DataSet` and `EncryptedDataSet`.

**Repository:**
- Updates build workflow to use Java 21.

**Documentation:**
- Updates documentation for better Markdown formatting, with proper paragraphing and use of code-blocks, aswell as removing links to APIDocs on inaccessible Quicksilver machine.
- Reformats JavaDoc comments throughout packages.