### PR TITLE
1.1.1-SNAPSHOT: Updated utilities version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ where the source data is held in encrypted form, with both symmetric and asymmet
 <dependency>
     <groupId>uk.ac.standrews.cs</groupId>
     <artifactId>ciesvium</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
 </dependency>
 ...
 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
             <version>${commons-csv-version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>uk.ac.standrews.cs</groupId>
             <artifactId>utilities</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>ciesvium</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>ciesvium</name>
 

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
@@ -432,7 +432,7 @@ public class DataSet {
         return new HashSet<>(strings).size() < strings.size();
     }
 
-    protected static Charset getCharset() {
+    protected Charset getCharset() {
         return DEFAULT_CHARSET;
     }
 }

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/DataSet.java
@@ -190,7 +190,6 @@ public class DataSet {
      *               dataset
      * @return the new dataset
      */
-    @SuppressWarnings("unused")
     public DataSet map(final Mapper mapper) {
 
         return new DataSet(mapper.mapColumnLabels(labels), mapRecords(mapper));
@@ -204,7 +203,6 @@ public class DataSet {
      *                 values
      * @return the new dataset
      */
-    @SuppressWarnings("unused")
     public DataSet extend(final Extender extender) {
 
         return new DataSet(extendLabels(extender), extendRecords(extender));
@@ -225,7 +223,6 @@ public class DataSet {
      *
      * @param values a new record
      */
-    @SuppressWarnings("unused")
     public void addRow(final String... values) {
 
         addRow(Arrays.asList(values));
@@ -275,7 +272,6 @@ public class DataSet {
      *
      * @param output_format the output format
      */
-    @SuppressWarnings("unused")
     public void setOutputFormat(final CSVFormat output_format) {
 
         this.output_format = output_format;
@@ -306,7 +302,6 @@ public class DataSet {
      * @param path the path of the output file
      * @throws IOException if this dataset cannot be printed to the given file
      */
-    @SuppressWarnings("unused")
     public void print(final Path path) throws IOException {
 
         try (final Writer writer = Files.newBufferedWriter(path)) {

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Extender.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Extender.java
@@ -37,7 +37,6 @@ public interface Extender {
      * @return a list of new values to be appended to the record in the extended
      * dataset
      */
-    @SuppressWarnings("unused")
     List<String> getAdditionalValues(List<String> record, DataSet data_set);
 
     /**

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Extender.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Extender.java
@@ -37,7 +37,7 @@ public interface Extender {
      * @return a list of new values to be appended to the record in the extended
      * dataset
      */
-    @SuppressWarnings("UnusedDeclaration")
+    @SuppressWarnings("unused")
     List<String> getAdditionalValues(List<String> record, DataSet data_set);
 
     /**

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Mapper.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Mapper.java
@@ -23,7 +23,6 @@ import java.util.List;
  *
  * @author Graham Kirby (graham.kirby@st-andrews.ac.uk)
  */
-@SuppressWarnings("unused")
 public interface Mapper {
 
     /**

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Mapper.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/derived/Mapper.java
@@ -23,7 +23,7 @@ import java.util.List;
  *
  * @author Graham Kirby (graham.kirby@st-andrews.ac.uk)
  */
-@SuppressWarnings("UnusedDeclaration")
+@SuppressWarnings("unused")
 public interface Mapper {
 
     /**

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
@@ -110,7 +110,7 @@ public class EncryptedDataSet extends DataSet {
      *                              user's private key
      * @throws IOException          if either input stream cannot be read
      */
-    @SuppressWarnings("UnusedDeclaration")
+    @SuppressWarnings("unused")
     public EncryptedDataSet(final InputStream source_data, final InputStream encrypted_key_stream) throws IOException, CryptoException {
 
         this(source_data, AsymmetricEncryption.getAESKey(encrypted_key_stream));

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSet.java
@@ -110,7 +110,6 @@ public class EncryptedDataSet extends DataSet {
      *                              user's private key
      * @throws IOException          if either input stream cannot be read
      */
-    @SuppressWarnings("unused")
     public EncryptedDataSet(final InputStream source_data, final InputStream encrypted_key_stream) throws IOException, CryptoException {
 
         this(source_data, AsymmetricEncryption.getAESKey(encrypted_key_stream));

--- a/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/examples/Tutorial.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/dataset/encrypted/examples/Tutorial.java
@@ -30,7 +30,7 @@ public class Tutorial {
 
     // These methods are defined in order to check that website examples compile (although not currently included in tutorial).
 
-    @SuppressWarnings("UnusedDeclaration")
+    @SuppressWarnings("unused")
     private static void create() throws CryptoException, IOException {
 
         final Path plain_text_path = Paths.get("/path/to/plain_text.csv");
@@ -47,7 +47,7 @@ public class Tutorial {
         new_data_set.print(cipher_text_path, key);
     }
 
-    @SuppressWarnings("UnusedDeclaration")
+    @SuppressWarnings("unused")
     private static void access() throws CryptoException, IOException {
 
         final Path cipher_text_path = Paths.get("/path/to/cipher_text.txt");

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/ConfidenceIntervals.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/ConfidenceIntervals.java
@@ -38,7 +38,7 @@ public class ConfidenceIntervals extends StatisticValues {
      *
      * @param data the numerical table
      */
-    @SuppressWarnings({"unused", "WeakerAccess"})
+    @SuppressWarnings("WeakerAccess")
     public ConfidenceIntervals(final List<List<Double>> data) {
 
         super(data);

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/ConfidenceIntervals.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/ConfidenceIntervals.java
@@ -38,7 +38,7 @@ public class ConfidenceIntervals extends StatisticValues {
      *
      * @param data the numerical table
      */
-    @SuppressWarnings({"UnusedDeclaration", "WeakerAccess"})
+    @SuppressWarnings({"unused", "WeakerAccess"})
     public ConfidenceIntervals(final List<List<Double>> data) {
 
         super(data);

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/Means.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/Means.java
@@ -32,7 +32,7 @@ public class Means extends StatisticValues {
      *
      * @param data the numerical table
      */
-    @SuppressWarnings({"unused", "WeakerAccess"})
+    @SuppressWarnings("WeakerAccess")
     public Means(final List<List<Double>> data) {
 
         super(data);

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/Means.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/Means.java
@@ -32,7 +32,7 @@ public class Means extends StatisticValues {
      *
      * @param data the numerical table
      */
-    @SuppressWarnings({"UnusedDeclaration", "WeakerAccess"})
+    @SuppressWarnings({"unused", "WeakerAccess"})
     public Means(final List<List<Double>> data) {
 
         super(data);

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/StatisticValues.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/StatisticValues.java
@@ -32,7 +32,6 @@ abstract class StatisticValues {
     private final List<List<Double>> data;
     private final List<Double> results;
 
-    @SuppressWarnings("unused")
     StatisticValues(final List<List<Double>> data) {
 
         this.data = data;

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/StatisticValues.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/StatisticValues.java
@@ -32,7 +32,7 @@ abstract class StatisticValues {
     private final List<List<Double>> data;
     private final List<Double> results;
 
-    @SuppressWarnings("UnusedDeclaration")
+    @SuppressWarnings("unused")
     StatisticValues(final List<List<Double>> data) {
 
         this.data = data;

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/TableGenerator.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/TableGenerator.java
@@ -56,7 +56,7 @@ public class TableGenerator {
      *                              corresponding value should be displayed as a
      *                              percentage.
      */
-    @SuppressWarnings("UnusedDeclaration")
+    @SuppressWarnings("unused")
     public TableGenerator(List<DataSet> data_sets, String first_column_heading, List<String> row_labels, List<Boolean> display_as_percentage) {
 
         this.row_labels = row_labels;
@@ -99,7 +99,7 @@ public class TableGenerator {
      *
      * @return the table
      */
-    @SuppressWarnings("UnusedDeclaration")
+    @SuppressWarnings("unused")
     public DataSet getTable() {
 
         /*

--- a/src/main/java/uk/ac/standrews/cs/utilities/tables/TableGenerator.java
+++ b/src/main/java/uk/ac/standrews/cs/utilities/tables/TableGenerator.java
@@ -56,7 +56,6 @@ public class TableGenerator {
      *                              corresponding value should be displayed as a
      *                              percentage.
      */
-    @SuppressWarnings("unused")
     public TableGenerator(List<DataSet> data_sets, String first_column_heading, List<String> row_labels, List<Boolean> display_as_percentage) {
 
         this.row_labels = row_labels;
@@ -99,7 +98,6 @@ public class TableGenerator {
      *
      * @return the table
      */
-    @SuppressWarnings("unused")
     public DataSet getTable() {
 
         /*

--- a/src/test/java/uk/ac/standrews/cs/utilities/dataset/DataSetErrorTest.java
+++ b/src/test/java/uk/ac/standrews/cs/utilities/dataset/DataSetErrorTest.java
@@ -16,7 +16,9 @@
  */
 package uk.ac.standrews.cs.utilities.dataset;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 
@@ -26,15 +28,19 @@ public class DataSetErrorTest {
     private static final String DATA_FILE_NAME2 = "csv_error_test_data2.csv";
     private static final char DELIMITER = ',';
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void fieldStartingButNotEndingWithQuoteThrowsException() throws IOException {
-
-        new DataSet(getClass().getResourceAsStream(DATA_FILE_NAME1), DELIMITER);
+        
+        assertThrows(RuntimeException.class, () -> {
+            new DataSet(getClass().getResourceAsStream(DATA_FILE_NAME1), DELIMITER);
+        });
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void quotedFieldContainingUnescapedQuotesThrowsException() throws IOException {
 
-        new DataSet(getClass().getResourceAsStream(DATA_FILE_NAME2), DELIMITER);
+        assertThrows(RuntimeException.class, () -> {
+            new DataSet(getClass().getResourceAsStream(DATA_FILE_NAME2), DELIMITER);
+        });
     }
 }

--- a/src/test/java/uk/ac/standrews/cs/utilities/dataset/DataSetTest.java
+++ b/src/test/java/uk/ac/standrews/cs/utilities/dataset/DataSetTest.java
@@ -16,8 +16,8 @@
  */
 package uk.ac.standrews.cs.utilities.dataset;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -26,7 +26,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DataSetTest {
 
@@ -37,7 +37,7 @@ public class DataSetTest {
     private DataSet non_empty_data_set;
     private DataSet empty_data_set;
 
-    @Before
+    @BeforeEach
     public void dataSetCreatedWithoutError() throws IOException {
 
 //        try (InputStreamReader reader = new InputStreamReader(getClass().getResourceAsStream(NON_EMPTY_DATA_SET_FILE_NAME))) {

--- a/src/test/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSetTest.java
+++ b/src/test/java/uk/ac/standrews/cs/utilities/dataset/encrypted/EncryptedDataSetTest.java
@@ -16,8 +16,8 @@
  */
 package uk.ac.standrews.cs.utilities.dataset.encrypted;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.ac.standrews.cs.utilities.FileManipulation;
 import uk.ac.standrews.cs.utilities.crypto.CryptoException;
 import uk.ac.standrews.cs.utilities.crypto.SymmetricEncryption;
@@ -30,7 +30,8 @@ import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EncryptedDataSetTest {
 
@@ -39,7 +40,7 @@ public class EncryptedDataSetTest {
 
     private DataSet data_set;
 
-    @Before
+    @BeforeEach
     public void setup() {
 
         data_set = new DataSet(getClass().getResourceAsStream(NON_EMPTY_DATA_SET_FILE_NAME), DELIMITER);
@@ -68,13 +69,16 @@ public class EncryptedDataSetTest {
         assertEquals(data_sets[0], data_sets[1]);
     }
 
-    @Test(expected = CryptoException.class)
+    @Test
     public void encryptedDataSetDecryptedWithWrongKeyThrowsException() throws CryptoException, IOException {
 
-        final SecretKey key1 = SymmetricEncryption.generateRandomKey();
-        final SecretKey key2 = SymmetricEncryption.generateRandomKey();
+        assertThrows(CryptoException.class, () -> {
+            final SecretKey key1 = SymmetricEncryption.generateRandomKey();
+            final SecretKey key2 = SymmetricEncryption.generateRandomKey();
 
-        createAndReadDataSet(key1, key2);
+            createAndReadDataSet(key1, key2);
+        });
+
     }
 
     private static EncryptedDataSet[] createAndReadDataSet(final SecretKey key1, final SecretKey key2) throws IOException, CryptoException {


### PR DESCRIPTION
## Overview
Patch to fix a number of small issues and update dependencies. Removes `static` modifier from `DataSet.getCharset()` so that the function can be overridden by child classes. Updates `utilities` dependency to benefit from improved `crypto` functionality for `EncryptedDataSet` and also migrates tests to JUnit5.

Closes #7, closes #8 , closes #9, closes #10

## Changelist
**Refactoring:**
-  Removes `static` modifier from `DataSet.getCharset()` to allow this function to be overridden by child classes.
- Address compiler warnings such as raw-types and unused variable and function declarations by adding mitigation and suppress warnings tags as relevant.

**Dependencies:**
- Updates [`common-pom`](https://github.com/stacs-srg/common-pom/) to [`4.1.0-SNAPSHOT`](https://github.com/stacs-srg/common-pom/pull/5) to take advantage of updated JDK and JUnit dependencies.
- Adds `JUnit5` dependency.
- Updates [`utilities`](https://github.com/stacs-srg/utilities/) dependency to [`1.1.0-SNAPSHOT`](https://github.com/stacs-srg/utilities/pull/13) to take advantages of patches and upgraded functionality.

**Other:**
- Replaces `@SuppressWarnings("UnusedDeclaration")` with `@SuppressWarnings("unused")`.
- Migrate tests in `src/main/test` to use JUnit5 instead of, the now unsupported, JUnit4.